### PR TITLE
空コメント投稿を修正

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -6,7 +6,6 @@ class CommentsController < ApplicationController
     else
       @prototype = @comment.prototype
       @comments = @prototype.comments
-      render prototype_path(params[:prototype_id])
     end
   end
 


### PR DESCRIPTION
#What
app/controllers/comments_controll.rbのcreateメソッドを修正

#Why
空でコメントを投稿すると、エラーが表示されるのを解消